### PR TITLE
Remove redundant "runaway" section

### DIFF
--- a/docs/Access.md
+++ b/docs/Access.md
@@ -95,7 +95,3 @@ This allows the collar only to block named avatars from using the collar.  Use s
 >Add to the Blocklist: `[prefix] add block [UUID]`  
 >Remove from the Blocklist: `[prefix] rm block [UUID]`
 >Add to Settings: `auth=block~<UUID>`
-
-# Runaway  
-This command wipes the owner list and returns all collar settings to default.   
->`auth=norun~1` to disable runaway in Settings.


### PR DESCRIPTION
There were two "Runaway" sections; second one had obsolete settings information (norun\~1 was replaced with runaway\~0 in v8)